### PR TITLE
Application level culling + better collision detection preformance

### DIFF
--- a/Game_Engine/Components/CameraComponent.cs
+++ b/Game_Engine/Components/CameraComponent.cs
@@ -13,6 +13,7 @@ namespace Game_Engine.Components
         public float FieldOfView { get; set; }
         public float AspectRatio { get; set; }
         public bool FollowPlayer { get; set; }
+        public BoundingFrustum BoundingFrustum { get; set; }
 		
         public CameraComponent(Entity id, Vector3 position, float aspectRatio, bool followPlayer) : base(id){
             ViewMatrix = new Matrix();
@@ -22,6 +23,7 @@ namespace Game_Engine.Components
             Position = position;
             AspectRatio = aspectRatio;
             FollowPlayer = followPlayer;
+            BoundingFrustum = new BoundingFrustum(ViewMatrix * ProjectionMatrix);
         }
     }
 }

--- a/Game_Engine/Systems/CameraSystem.cs
+++ b/Game_Engine/Systems/CameraSystem.cs
@@ -27,7 +27,7 @@ namespace Game_Engine.Systems
                 }
                 cameraComponent.ViewMatrix = Matrix.CreateLookAt(cameraComponent.Position, cameraComponent.Target, Vector3.Up);
                 cameraComponent.ProjectionMatrix = Matrix.CreatePerspectiveFieldOfView(
-                cameraComponent.FieldOfView, cameraComponent.AspectRatio, 1f, 1000f);
+                cameraComponent.FieldOfView, cameraComponent.AspectRatio, 1f, 700f);
                 if (cameraComponent.FollowPlayer){
                     FollowPlayer(cameraComponentPair.Key);
                 }

--- a/Game_Engine/Systems/CameraSystem.cs
+++ b/Game_Engine/Systems/CameraSystem.cs
@@ -28,6 +28,8 @@ namespace Game_Engine.Systems
                 cameraComponent.ViewMatrix = Matrix.CreateLookAt(cameraComponent.Position, cameraComponent.Target, Vector3.Up);
                 cameraComponent.ProjectionMatrix = Matrix.CreatePerspectiveFieldOfView(
                 cameraComponent.FieldOfView, cameraComponent.AspectRatio, 1f, 700f);
+                cameraComponent.BoundingFrustum = new BoundingFrustum(cameraComponent.ViewMatrix * cameraComponent.ProjectionMatrix);
+                //Console.WriteLine(cameraComponent.BoundingFrustum.Matrix);
                 if (cameraComponent.FollowPlayer){
                     FollowPlayer(cameraComponentPair.Key);
                 }

--- a/Game_Engine/Systems/ModelRenderSystem.cs
+++ b/Game_Engine/Systems/ModelRenderSystem.cs
@@ -53,27 +53,27 @@ namespace Game_Engine.Systems
             foreach(var modelComponentPair in modelComponents)
             {
                 ModelComponent model = modelComponentPair.Value as ModelComponent;
-                TextureComponent textureComponent = ComponentManager.Instance.ConcurrentGetComponentOfEntity<TextureComponent>(modelComponentPair.Key);
-                 model.BoneTransformations[0] = model.World;
-                //model.Model.CopyAbsoluteBoneTransformsTo(model.BoneTransformations);
-                //model.BoneTransformations = new Matrix[model.Model.Bones.Count];
-                //model.Model.CopyAbsoluteBoneTransformsTo(model.BoneTransformations);
-                
-                foreach (var modelMesh in model.Model.Meshes)
+                if (cameraComponent.BoundingFrustum.Intersects(model.Model.Meshes[0].BoundingSphere))
                 {
-                    foreach (BasicEffect effect in modelMesh.Effects)
+                    TextureComponent textureComponent = ComponentManager.Instance.ConcurrentGetComponentOfEntity<TextureComponent>(modelComponentPair.Key);
+                    model.BoneTransformations[0] = model.World;
+
+                    foreach (var modelMesh in model.Model.Meshes)
                     {
-                        effect.World = model.BoneTransformations[modelMesh.ParentBone.Index] * EngineHelper.Instance().WorldMatrix;
-                        effect.View = cameraComponent.ViewMatrix;
-                        effect.Projection = cameraComponent.ProjectionMatrix;
-                        effect.EnableDefaultLighting();
-                        effect.LightingEnabled = true;
-                        if(textureComponent != null)
+                        foreach (BasicEffect effect in modelMesh.Effects)
                         {
-                            effect.Texture = textureComponent.Texture;
-                            effect.TextureEnabled = true;
+                            effect.World = model.BoneTransformations[modelMesh.ParentBone.Index] * EngineHelper.Instance().WorldMatrix;
+                            effect.View = cameraComponent.ViewMatrix;
+                            effect.Projection = cameraComponent.ProjectionMatrix;
+                            effect.EnableDefaultLighting();
+                            effect.LightingEnabled = true;
+                            if (textureComponent != null)
+                            {
+                                effect.Texture = textureComponent.Texture;
+                                effect.TextureEnabled = true;
+                            }
+                            modelMesh.Draw();
                         }
-                        modelMesh.Draw();
                     }
                 }
             }

--- a/Game_Engine/Systems/ModelRenderSystem.cs
+++ b/Game_Engine/Systems/ModelRenderSystem.cs
@@ -53,7 +53,8 @@ namespace Game_Engine.Systems
             foreach(var modelComponentPair in modelComponents)
             {
                 ModelComponent model = modelComponentPair.Value as ModelComponent;
-                if (cameraComponent.BoundingFrustum.Intersects(model.Model.Meshes[0].BoundingSphere))
+                var collisionComponent = ComponentManager.Instance.ConcurrentGetComponentOfEntity<CollisionComponent>(modelComponentPair.Key);
+                if (cameraComponent.BoundingFrustum.Intersects(collisionComponent.BoundingShape))
                 {
                     TextureComponent textureComponent = ComponentManager.Instance.ConcurrentGetComponentOfEntity<TextureComponent>(modelComponentPair.Key);
                     model.BoneTransformations[0] = model.World;

--- a/Game_Engine/Systems/PhysicsSystem.cs
+++ b/Game_Engine/Systems/PhysicsSystem.cs
@@ -2,6 +2,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Threading.Tasks;
 using Game_Engine.Components;
 using Game_Engine.Entities;
@@ -66,25 +67,28 @@ namespace Game_Engine.Systems
             {
                 Entity sourceEntity = sourceCollisionComponentPair.Key;
                 var sourceCollisionComponent = sourceCollisionComponentPair.Value as CollisionComponent;
-
+                var cameraComponent = componentManager.GetConcurrentDictionary<CameraComponent>().Values.First() as CameraComponent; //get the cameracomponent
+                
                 /*
-                 * Only check collsion on blocks within the cameraComponent farplane,
-                 * otherwise we get horrendous lag when we check all blocks on entire map
-                 */
-                foreach (var targetCollisionComponentPair in collisionComponentPairs)
+                * Only check collsion on blocks within the cameraComponent farplane,
+                * otherwise we get horrendous lag when we check all blocks on entire map
+                */
+                if (cameraComponent.BoundingFrustum.Intersects(sourceCollisionComponent.BoundingShape))
                 {
-
-                    Entity targetEntity = targetCollisionComponentPair.Key;
-                    CollisionComponent targetCollisionComponent = targetCollisionComponentPair.Value as CollisionComponent;
-
-                    if (sourceCollisionComponent.ComponentId != targetCollisionComponent.ComponentId &&
-                        sourceCollisionComponent.BoundingShape.Intersects(targetCollisionComponent.BoundingShape))
+                    foreach (var targetCollisionComponentPair in collisionComponentPairs)
                     {
-                        CollisionManager.Instance.AddCollisionPair(sourceEntity, targetEntity);
-                        found = true; //Temp debug flag
-                        //Console.WriteLine(sourceBoundingSphereComponent.ComponentId.ToString() + " Intersects " + targetBoundingSphereComponent.ComponentId.ToString());
+                        Entity targetEntity = targetCollisionComponentPair.Key;
+                        CollisionComponent targetCollisionComponent = targetCollisionComponentPair.Value as CollisionComponent;
+                        if (sourceCollisionComponent.ComponentId != targetCollisionComponent.ComponentId &&
+                        sourceCollisionComponent.BoundingShape.Intersects(targetCollisionComponent.BoundingShape))
+                        {
+                            CollisionManager.Instance.AddCollisionPair(sourceEntity, targetEntity);
+                            found = true; //Temp debug flag
+                                          //Console.WriteLine(sourceBoundingSphereComponent.ComponentId.ToString() + " Intersects " + targetBoundingSphereComponent.ComponentId.ToString());
+                        }
                     }
-                } 
+                }
+                
             });
             if (!found) //Temp debug check
             {

--- a/Game_Engine/Systems/PhysicsSystem.cs
+++ b/Game_Engine/Systems/PhysicsSystem.cs
@@ -67,6 +67,10 @@ namespace Game_Engine.Systems
                 Entity sourceEntity = sourceCollisionComponentPair.Key;
                 var sourceCollisionComponent = sourceCollisionComponentPair.Value as CollisionComponent;
 
+                /*
+                 * Only check collsion on blocks within the cameraComponent farplane,
+                 * otherwise we get horrendous lag when we check all blocks on entire map
+                 */
                 foreach (var targetCollisionComponentPair in collisionComponentPairs)
                 {
 

--- a/Game_Engine/Systems/PhysicsSystem.cs
+++ b/Game_Engine/Systems/PhysicsSystem.cs
@@ -61,18 +61,13 @@ namespace Game_Engine.Systems
         private void CheckCollision()
         {
             ConcurrentDictionary<Entity, Component> collisionComponentPairs = componentManager.GetConcurrentDictionary<CollisionComponent>();
+            var playerComponents = componentManager.GetConcurrentDictionary<PlayerComponent>();
             bool found = false; //Temp debug flag
 
-            Parallel.ForEach(collisionComponentPairs, sourceCollisionComponentPair =>
+            Parallel.ForEach(playerComponents, playerComponentPair =>
             {
-                Entity sourceEntity = sourceCollisionComponentPair.Key;
-                var sourceCollisionComponent = sourceCollisionComponentPair.Value as CollisionComponent;
-                var cameraComponent = componentManager.GetConcurrentDictionary<CameraComponent>().Values.First() as CameraComponent; //get the cameracomponent
-                
-                /*
-                * Only check collsion on blocks within the cameraComponent farplane,
-                * otherwise we get horrendous lag when we check all blocks on entire map
-                */
+                Entity sourceEntity = playerComponentPair.Key;
+                var sourceCollisionComponent = componentManager.ConcurrentGetComponentOfEntity<CollisionComponent>(playerComponentPair.Key);
                 
                 foreach (var targetCollisionComponentPair in collisionComponentPairs)
                 {

--- a/Game_Engine/Systems/PhysicsSystem.cs
+++ b/Game_Engine/Systems/PhysicsSystem.cs
@@ -73,22 +73,19 @@ namespace Game_Engine.Systems
                 * Only check collsion on blocks within the cameraComponent farplane,
                 * otherwise we get horrendous lag when we check all blocks on entire map
                 */
-                if (cameraComponent.BoundingFrustum.Intersects(sourceCollisionComponent.BoundingShape))
+                
+                foreach (var targetCollisionComponentPair in collisionComponentPairs)
                 {
-                    foreach (var targetCollisionComponentPair in collisionComponentPairs)
+                    Entity targetEntity = targetCollisionComponentPair.Key;
+                    CollisionComponent targetCollisionComponent = targetCollisionComponentPair.Value as CollisionComponent;
+                    if (sourceCollisionComponent.ComponentId != targetCollisionComponent.ComponentId &&
+                    sourceCollisionComponent.BoundingShape.Intersects(targetCollisionComponent.BoundingShape))
                     {
-                        Entity targetEntity = targetCollisionComponentPair.Key;
-                        CollisionComponent targetCollisionComponent = targetCollisionComponentPair.Value as CollisionComponent;
-                        if (sourceCollisionComponent.ComponentId != targetCollisionComponent.ComponentId &&
-                        sourceCollisionComponent.BoundingShape.Intersects(targetCollisionComponent.BoundingShape))
-                        {
-                            CollisionManager.Instance.AddCollisionPair(sourceEntity, targetEntity);
-                            found = true; //Temp debug flag
-                                          //Console.WriteLine(sourceBoundingSphereComponent.ComponentId.ToString() + " Intersects " + targetBoundingSphereComponent.ComponentId.ToString());
-                        }
+                        CollisionManager.Instance.AddCollisionPair(sourceEntity, targetEntity);
+                        found = true; //Temp debug flag
+                                        //Console.WriteLine(sourceBoundingSphereComponent.ComponentId.ToString() + " Intersects " + targetBoundingSphereComponent.ComponentId.ToString());
                     }
                 }
-                
             });
             if (!found) //Temp debug check
             {

--- a/Game_Engine/Systems/PhysicsSystem.cs
+++ b/Game_Engine/Systems/PhysicsSystem.cs
@@ -13,14 +13,20 @@ using Microsoft.Xna.Framework.Input;
 
 namespace Game_Engine.Systems
 {
-    /*
-     * System to handle all physics updates including 3D transformations based on velocity, friction, and collision.
-     * PhysicsSystem uses parallel foreach loops to improve performance, this does not require locks as the component manager is thread safe.
-     */
+    /// <summary>
+    /// System to handle all physics updates including 3D transformations based on velocity, friction, and collision.
+    /// PhysicsSystem uses parallel foreach loops to improve performance, this does not require locks as the component manager is thread safe.
+    /// If the parameter passed to the constructor is true we compare collisions with all models instead of just players and other models
+    /// </summary>
     public class PhysicsSystem : IUpdateableSystem
     {
-
         ComponentManager componentManager = ComponentManager.Instance;
+        private bool compareAllModels;
+
+        public PhysicsSystem(bool compareAllModels = false)
+        {
+            this.compareAllModels = compareAllModels;
+        }
 
         public void Update(GameTime gameTime)
         {
@@ -55,36 +61,50 @@ namespace Game_Engine.Systems
         }
 
         /// <summary>
-        /// Checks intersections for all BoundingSphereComponents.
-        /// Currently only identifies collision, taking action based on collision is TODO.
+        /// Checks intersections for all CollisionComponents if compareAllModels is set to true
+        /// Otherwise we only compare players to all other models and reducing number of comparisons. 
         /// </summary>
         private void CheckCollision()
         {
             ConcurrentDictionary<Entity, Component> collisionComponentPairs = componentManager.GetConcurrentDictionary<CollisionComponent>();
             var playerComponents = componentManager.GetConcurrentDictionary<PlayerComponent>();
-            bool found = false; //Temp debug flag
-
-            Parallel.ForEach(playerComponents, playerComponentPair =>
+            if (compareAllModels)
             {
-                Entity sourceEntity = playerComponentPair.Key;
-                var sourceCollisionComponent = componentManager.ConcurrentGetComponentOfEntity<CollisionComponent>(playerComponentPair.Key);
-                
-                foreach (var targetCollisionComponentPair in collisionComponentPairs)
+                Parallel.ForEach(collisionComponentPairs, sourceCollisionPair =>
                 {
-                    Entity targetEntity = targetCollisionComponentPair.Key;
-                    CollisionComponent targetCollisionComponent = targetCollisionComponentPair.Value as CollisionComponent;
-                    if (sourceCollisionComponent.ComponentId != targetCollisionComponent.ComponentId &&
-                    sourceCollisionComponent.BoundingShape.Intersects(targetCollisionComponent.BoundingShape))
+                    Entity sourceEntity = sourceCollisionPair.Key;
+                    var sourceCollisionComponent = sourceCollisionPair.Value as CollisionComponent;
+
+                    foreach (var targetCollisionComponentPair in collisionComponentPairs)
                     {
-                        CollisionManager.Instance.AddCollisionPair(sourceEntity, targetEntity);
-                        found = true; //Temp debug flag
-                                        //Console.WriteLine(sourceBoundingSphereComponent.ComponentId.ToString() + " Intersects " + targetBoundingSphereComponent.ComponentId.ToString());
+                        Entity targetEntity = targetCollisionComponentPair.Key;
+                        CollisionComponent targetCollisionComponent = targetCollisionComponentPair.Value as CollisionComponent;
+                        if (sourceCollisionComponent.ComponentId != targetCollisionComponent.ComponentId &&
+                        sourceCollisionComponent.BoundingShape.Intersects(targetCollisionComponent.BoundingShape))
+                        {
+                            CollisionManager.Instance.AddCollisionPair(sourceEntity, targetEntity);
+                        }
                     }
-                }
-            });
-            if (!found) //Temp debug check
+                });
+            }
+            else
             {
-                //Console.WriteLine("No BoundingSphereComponents intersect");
+                Parallel.ForEach(playerComponents, playerComponentPair =>
+                {
+                    Entity sourceEntity = playerComponentPair.Key;
+                    var sourceCollisionComponent = componentManager.ConcurrentGetComponentOfEntity<CollisionComponent>(playerComponentPair.Key);
+
+                    foreach (var targetCollisionComponentPair in collisionComponentPairs)
+                    {
+                        Entity targetEntity = targetCollisionComponentPair.Key;
+                        CollisionComponent targetCollisionComponent = targetCollisionComponentPair.Value as CollisionComponent;
+                        if (sourceCollisionComponent.ComponentId != targetCollisionComponent.ComponentId &&
+                        sourceCollisionComponent.BoundingShape.Intersects(targetCollisionComponent.BoundingShape))
+                        {
+                            CollisionManager.Instance.AddCollisionPair(sourceEntity, targetEntity);
+                        }
+                    }
+                });
             }
         }
 

--- a/thundercats/GameStates/States/PlayingStates/PlayingLocalGame.cs
+++ b/thundercats/GameStates/States/PlayingStates/PlayingLocalGame.cs
@@ -75,7 +75,7 @@ namespace thundercats.GameStates.States.PlayingStates
         private void InitWorld()
         {
             worldGenerator = new WorldGenerator("Somebody once told me the wolrd is gonna roll me");
-            world = GenerateWorld(3, 5);
+            world = GenerateWorld(3, 100);
             worldEntity = new Entity[world.GetLength(0), world.GetLength(1)];
             int distanceBetweenBlocksX = -100;
             int distanceBetweenBlocksZ = 50;


### PR DESCRIPTION
We only render models which intersets with the cameras boundingFrustum. 
The collision detection was reworked to only compare players to other players and players to blocks. This should decrease number of comparisons by several ~~hundred~~ percent. 